### PR TITLE
Feat : [004-JWT] JWT 토큰 발급 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ dependencies {
     // json
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
+    // jwt
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/su/look_at_meong/config/SecurityConfig.java
+++ b/src/main/java/com/su/look_at_meong/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.su.look_at_meong.config;
 
+import com.su.look_at_meong.config.jwt.JwtAuthenticationFilter;
+import com.su.look_at_meong.config.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -9,11 +12,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 @Slf4j
 public class SecurityConfig {
+
+    private final JwtProvider jwtProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -25,7 +32,7 @@ public class SecurityConfig {
             .authorizeRequests()
             .antMatchers("/**").permitAll()
             .and()
-            //TODO jwt 필터 추가
+            .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
             .build();
     }
 

--- a/src/main/java/com/su/look_at_meong/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/su/look_at_meong/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.su.look_at_meong.config.jwt;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String jwt = resolveToken(request);
+
+        if (StringUtils.hasText(jwt) && jwtProvider.validateToken(jwt)) {
+            Authentication authentication = jwtProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/su/look_at_meong/config/jwt/JwtProvider.java
+++ b/src/main/java/com/su/look_at_meong/config/jwt/JwtProvider.java
@@ -1,0 +1,121 @@
+package com.su.look_at_meong.config.jwt;
+
+import com.su.look_at_meong.constatnt.Role;
+import com.su.look_at_meong.model.member.dto.TokenDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private final Key key;
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // access 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // refresh 7일
+
+    public JwtProvider(@Value("${spring.jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public TokenDto generateTokenDto(String email) {
+
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
+            .setSubject(email) //payload "sub" : "name"
+            .claim(AUTHORITIES_KEY, Role.MEMBER) //payload "auth" : "ROLE_USER"
+            .setExpiration(accessTokenExpiresIn) //payload "exp" : 1234567890 (10자리)
+            .signWith(key, SignatureAlgorithm.HS512) //header "alg" : HS512 (해싱 알고리즘 HS512)
+            .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+            .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact();
+
+        return TokenDto.builder()
+            .grantType(BEARER_TYPE)
+            .accessToken(accessToken)
+            .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+            .refreshToken(refreshToken)
+            .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임으로 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities =
+            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    // 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("JWT 서명의 형식이 잘못되었습니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 JWT 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("잘못된 JWT 입니다.");
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody();
+        }catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/su/look_at_meong/model/member/dto/TokenDto.java
+++ b/src/main/java/com/su/look_at_meong/model/member/dto/TokenDto.java
@@ -1,0 +1,17 @@
+package com.su.look_at_meong.model.member.dto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class TokenDto {
+
+    private String grantType; // Bearer
+    private String accessToken;
+    private String refreshToken;
+    private Long accessTokenExpiresIn;
+}


### PR DESCRIPTION
Changes
---
- security 와 JWT 를 같이 사용하기위해 SecurityFilterChain 에 JwtAuthenticationFilter 를 추가함
- provider 는 JWT 관련 로직을 수행함

Background
---
- jwt secret key를 암호화하여 저장
- generateTokenDto는 email을 Claim으로 하여 JWT를 생성