### PR TITLE
Feat : [007-KAKAO-LOGOUT] 카카오 로그아웃 서비스 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/src/main/java/com/su/look_at_meong/config/RedisConfig.java
+++ b/src/main/java/com/su/look_at_meong/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.su.look_at_meong.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, Object> redisTemplate = new org.springframework.data.redis.core.RedisTemplate<>();
+        StringRedisSerializer serializer = new StringRedisSerializer();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(serializer);
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/su/look_at_meong/config/jwt/JwtProvider.java
+++ b/src/main/java/com/su/look_at_meong/config/jwt/JwtProvider.java
@@ -36,6 +36,7 @@ public class JwtProvider {
     private final Key key;
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "bearer";
+    private static final String CLAIM_KEY = "email";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // access 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // refresh 7일
 
@@ -89,6 +90,16 @@ public class JwtProvider {
         UserDetails principal = new User(claims.getSubject(), "", authorities);
 
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public String getEmail(String token) {
+        return parseClaims(token).get(CLAIM_KEY, String.class);
+    }
+
+    public long getExpiration(String token) {
+        long time = System.currentTimeMillis();
+        Date expiration = parseClaims(token).getExpiration();
+        return expiration.getTime() - time;
     }
 
     // 토큰 유효성 검증

--- a/src/main/java/com/su/look_at_meong/controller/oauth/OAuthController.java
+++ b/src/main/java/com/su/look_at_meong/controller/oauth/OAuthController.java
@@ -1,6 +1,7 @@
 package com.su.look_at_meong.controller.oauth;
 
 import com.su.look_at_meong.service.oauth.OAuthService;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -22,5 +23,11 @@ public class OAuthController {
 
         log.info("###Code : {}###", code);
         return ResponseEntity.ok(oAuthService.kakaoLogin(code));
+    }
+
+    @GetMapping("/kakao/logout")
+    public ResponseEntity<?> kakaoLogout(HttpServletRequest request) {
+
+        return ResponseEntity.ok(oAuthService.kakaoLogout(request));
     }
 }

--- a/src/main/java/com/su/look_at_meong/exception/constant/MemberErrorCode.java
+++ b/src/main/java/com/su/look_at_meong/exception/constant/MemberErrorCode.java
@@ -13,6 +13,7 @@ public enum MemberErrorCode implements ErrorCode {
     PASSWORD_ENTERED_IS_INCORRECT(HttpStatus.BAD_REQUEST, "입력하신 비밀번호가 올바르지 않습니다."),
     ALREADY_RESISTER_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
     INVALID_PARSE_ERROR(HttpStatus.BAD_REQUEST, "JSON 파싱에 실패하였습니다."),
+    ALREADY_LOGOUT_MEMBER(HttpStatus.BAD_REQUEST, " 로그아웃된 사용자 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/su/look_at_meong/model/member/dto/LogoutDto.java
+++ b/src/main/java/com/su/look_at_meong/model/member/dto/LogoutDto.java
@@ -1,0 +1,18 @@
+package com.su.look_at_meong.model.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class LogoutDto {
+
+    private String email;
+}

--- a/src/test/java/com/su/look_at_meong/controller/member/SignInControllerTest.java
+++ b/src/test/java/com/su/look_at_meong/controller/member/SignInControllerTest.java
@@ -49,7 +49,10 @@ class SignInControllerTest {
         SignInDto request = signInDto();
 
         given(memberService.signIn(any()))
-            .willReturn(TokenDto.builder().build());
+            .willReturn(TokenDto.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build());
 
         //when
         ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
Changes
---
- 카카오 로그아웃 구현
- 기존 로그인에서 String token 리턴에서 accessToken, refreshToken 을 담은 tokenDto리턴
refresh토큰을 생성 시 redis에 저장