### PR TITLE
Feat : [008-MEMBER-INFO-MODIFY] 회원 정보 수정 구현

### DIFF
--- a/member-api.http
+++ b/member-api.http
@@ -3,7 +3,7 @@ POST http://localhost:8081/signup/member
 Content-Type: application/json
 
 {
-  "email": "test@test.com",
+  "email": "test123@test.com",
   "password": "1234",
   "name": "홍길동",
   "phone": "010-1111-1111"
@@ -34,4 +34,16 @@ Content-Type: application/json
 {
   "email": "test@test.com",
   "password": "1111"
+}
+
+### 회원 정보 수정
+POST http://localhost:8081/modify/member
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiYXV0aCI6Ik1FTUJFUiIsImV4cCI6MTY4NzUwNDgxN30.nt5YvTYSTwSfMYDJNudwb6pVlLbwN5t_y-4vP78p6e8ajpJ7lPEwnTnPOsbxyy-e-nNxmzC3g4MdevLU5AfKZg
+
+{
+  "currentPassword": "1234",
+  "updatePassword": "",
+  "name": "김나나",
+  "phone": "010-2222-1111"
 }

--- a/member-api.http
+++ b/member-api.http
@@ -3,7 +3,7 @@ POST http://localhost:8081/signup/member
 Content-Type: application/json
 
 {
-  "email": "test123@test.com",
+  "email": "test@test.com",
   "password": "1234",
   "name": "홍길동",
   "phone": "010-1111-1111"
@@ -37,9 +37,9 @@ Content-Type: application/json
 }
 
 ### 회원 정보 수정
-POST http://localhost:8081/modify/member
+PUT http://localhost:8081/modify/member
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiYXV0aCI6Ik1FTUJFUiIsImV4cCI6MTY4NzUwNDgxN30.nt5YvTYSTwSfMYDJNudwb6pVlLbwN5t_y-4vP78p6e8ajpJ7lPEwnTnPOsbxyy-e-nNxmzC3g4MdevLU5AfKZg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiYXV0aCI6Ik1FTUJFUiIsImV4cCI6MTY4Nzg1ODY4MX0.ETBnsd2u-OfqmKKziAhVYOrvFO9UcPBtUW7lWAMJ8xAQL1O8T9Mu0MenP01fR5ogHXF5m_-GeSzYvGlOODPLPg
 
 {
   "currentPassword": "1234",

--- a/src/main/java/com/su/look_at_meong/config/SecurityConfig.java
+++ b/src/main/java/com/su/look_at_meong/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeRequests()
-            .antMatchers("/signup/**", "/signIn/**", "/oauth/**").permitAll()
+            .antMatchers("/signup/**", "/signIn/**", "/oauth/**", "/modify/**").permitAll()
             .and()
             .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
             .build();

--- a/src/main/java/com/su/look_at_meong/config/jwt/JwtProvider.java
+++ b/src/main/java/com/su/look_at_meong/config/jwt/JwtProvider.java
@@ -14,6 +14,7 @@ import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
@@ -39,6 +40,7 @@ public class JwtProvider {
     private static final String CLAIM_KEY = "email";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; // access 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // refresh 7일
+    private static final String ROLE = "MEMBER";
 
     public JwtProvider(@Value("${spring.jwt.secret}") String secretKey) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
@@ -72,24 +74,10 @@ public class JwtProvider {
             .build();
     }
 
-    public Authentication getAuthentication(String accessToken) {
+    public UsernamePasswordAuthenticationToken getAuthentication(String accessToken) {
 
-        // 토큰 복호화
-        Claims claims = parseClaims(accessToken);
-
-        if (claims.get(AUTHORITIES_KEY) == null) {
-            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
-        }
-
-        // 클레임으로 권한 정보 가져오기
-        Collection<? extends GrantedAuthority> authorities =
-            Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
-
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
-
-        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+        return new UsernamePasswordAuthenticationToken(getEmail(accessToken), null,
+            List.of(new SimpleGrantedAuthority(ROLE)));
     }
 
     public String getEmail(String token) {

--- a/src/main/java/com/su/look_at_meong/controller/member/MemberInfoModifyController.java
+++ b/src/main/java/com/su/look_at_meong/controller/member/MemberInfoModifyController.java
@@ -1,0 +1,27 @@
+package com.su.look_at_meong.controller.member;
+
+import com.su.look_at_meong.model.member.dto.ModifyMemberDto;
+import com.su.look_at_meong.model.member.entity.ModifyMember;
+import com.su.look_at_meong.service.member.MemberService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/modify")
+public class MemberInfoModifyController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/member")
+    public ResponseEntity<ModifyMemberDto> modify(Principal principal
+        , @RequestBody ModifyMember modifyMember) {
+
+        return ResponseEntity.ok(memberService.modifyMemberInfo(principal.getName(),modifyMember));
+    }
+}

--- a/src/main/java/com/su/look_at_meong/controller/member/MemberInfoModifyController.java
+++ b/src/main/java/com/su/look_at_meong/controller/member/MemberInfoModifyController.java
@@ -6,7 +6,7 @@ import com.su.look_at_meong.service.member.MemberService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +18,7 @@ public class MemberInfoModifyController {
 
     private final MemberService memberService;
 
-    @PostMapping("/member")
+    @PutMapping("/member")
     public ResponseEntity<ModifyMemberDto> modify(Principal principal
         , @RequestBody ModifyMember modifyMember) {
 

--- a/src/main/java/com/su/look_at_meong/model/member/dto/ModifyMemberDto.java
+++ b/src/main/java/com/su/look_at_meong/model/member/dto/ModifyMemberDto.java
@@ -1,0 +1,25 @@
+package com.su.look_at_meong.model.member.dto;
+
+import com.su.look_at_meong.model.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ModifyMemberDto {
+    private String name;
+    private String phone;
+
+    public ModifyMemberDto from(Member member) {
+        return ModifyMemberDto.builder()
+            .name(member.getName())
+            .phone(member.getPhone())
+            .build();
+    }
+}

--- a/src/main/java/com/su/look_at_meong/model/member/entity/Member.java
+++ b/src/main/java/com/su/look_at_meong/model/member/entity/Member.java
@@ -43,4 +43,9 @@ public class Member extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    public void updateMember(ModifyMember modifyMember) {
+        this.setName(modifyMember.getName());
+        this.setPhone(modifyMember.getPhone());
+    }
 }

--- a/src/main/java/com/su/look_at_meong/model/member/entity/ModifyMember.java
+++ b/src/main/java/com/su/look_at_meong/model/member/entity/ModifyMember.java
@@ -1,0 +1,20 @@
+package com.su.look_at_meong.model.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ModifyMember {
+
+    private String currentPassword;
+    private String updatePassword;
+    private String name;
+    private String phone;
+}

--- a/src/main/java/com/su/look_at_meong/service/member/MemberService.java
+++ b/src/main/java/com/su/look_at_meong/service/member/MemberService.java
@@ -8,11 +8,14 @@ import com.su.look_at_meong.config.jwt.JwtProvider;
 import com.su.look_at_meong.constatnt.Role;
 import com.su.look_at_meong.exception.RestApiException;
 import com.su.look_at_meong.model.member.dto.MemberDto;
+import com.su.look_at_meong.model.member.dto.ModifyMemberDto;
 import com.su.look_at_meong.model.member.dto.SignInDto;
 import com.su.look_at_meong.model.member.dto.SignUpFormDto;
 import com.su.look_at_meong.model.member.dto.TokenDto;
 import com.su.look_at_meong.model.member.entity.Member;
+import com.su.look_at_meong.model.member.entity.ModifyMember;
 import com.su.look_at_meong.repository.MemberRepository;
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -68,5 +71,24 @@ public class MemberService {
 
     private boolean validationLogin(String formPassword, String encodingPassword) {
         return passwordEncoder.matches(formPassword, encodingPassword);
+    }
+
+    public ModifyMemberDto modifyMemberInfo(String email, ModifyMember modifyMember) {
+
+        var member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new RestApiException(NOT_FOUND_MEMBER));
+
+        if (!passwordEncoder.matches(modifyMember.getCurrentPassword(), member.getPassword())) {
+            throw new RestApiException(PASSWORD_ENTERED_IS_INCORRECT);
+        }
+
+        member.setName(modifyMember.getName());
+        member.setPhone(modifyMember.getPhone());
+
+        if (!modifyMember.getUpdatePassword().isEmpty()) {
+            member.setPassword(passwordEncoder.encode(modifyMember.getUpdatePassword()));
+        }
+
+        return new ModifyMemberDto().from(memberRepository.save(member));
     }
 }

--- a/src/main/java/com/su/look_at_meong/service/member/MemberService.java
+++ b/src/main/java/com/su/look_at_meong/service/member/MemberService.java
@@ -75,19 +75,18 @@ public class MemberService {
 
     public ModifyMemberDto modifyMemberInfo(String email, ModifyMember modifyMember) {
 
-        var member = memberRepository.findByEmail(email)
+        Member member = memberRepository.findByEmail(email)
             .orElseThrow(() -> new RestApiException(NOT_FOUND_MEMBER));
 
         if (!passwordEncoder.matches(modifyMember.getCurrentPassword(), member.getPassword())) {
             throw new RestApiException(PASSWORD_ENTERED_IS_INCORRECT);
         }
 
-        member.setName(modifyMember.getName());
-        member.setPhone(modifyMember.getPhone());
-
         if (!modifyMember.getUpdatePassword().isEmpty()) {
             member.setPassword(passwordEncoder.encode(modifyMember.getUpdatePassword()));
         }
+
+        member.updateMember(modifyMember);
 
         return new ModifyMemberDto().from(memberRepository.save(member));
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,4 +15,4 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update

--- a/src/test/java/com/su/look_at_meong/controller/member/MemberInfoModifyControllerTest.java
+++ b/src/test/java/com/su/look_at_meong/controller/member/MemberInfoModifyControllerTest.java
@@ -1,0 +1,130 @@
+package com.su.look_at_meong.controller.member;
+
+import static com.su.look_at_meong.exception.constant.MemberErrorCode.NOT_FOUND_MEMBER;
+import static com.su.look_at_meong.exception.constant.MemberErrorCode.PASSWORD_ENTERED_IS_INCORRECT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.gson.Gson;
+import com.su.look_at_meong.exception.RestApiException;
+import com.su.look_at_meong.model.member.dto.ModifyMemberDto;
+import com.su.look_at_meong.model.member.entity.ModifyMember;
+import com.su.look_at_meong.service.member.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class MemberInfoModifyControllerTest {
+
+    @InjectMocks
+    private MemberInfoModifyController memberInfoModifyController;
+
+    @Mock
+    private MemberService memberService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(memberInfoModifyController).build();
+    }
+
+    @DisplayName("회원 정보 수정")
+    @Test
+    void Modify_Member_Info() throws Exception {
+        //given
+        ModifyMember request = ModifyMember.builder()
+            .currentPassword("1234")
+            .updatePassword("")
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        ModifyMemberDto response = ModifyMemberDto.builder()
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        given(memberService.modifyMemberInfo(any(), any())).willReturn(response);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.put("/modify/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new Gson().toJson(request))
+        );
+
+        //then
+        MvcResult mvcResult = resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.name").value("김나나"))
+            .andExpect(jsonPath("$.phone").value("010-2222-1111"))
+            .andReturn();
+    }
+
+    @DisplayName("회원 정보 수정 실패 - 사용자 없음")
+    @Test
+    void Modify_Member_Info_Fail() throws Exception {
+        //given
+        ModifyMember request = ModifyMember.builder()
+            .currentPassword("1234")
+            .updatePassword("")
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        given(memberService.modifyMemberInfo(any(), any())).willThrow(new RestApiException(NOT_FOUND_MEMBER));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.put("/modify/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new Gson().toJson(request))
+        );
+
+        //then
+        MvcResult mvcResult = resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.errorCode").value("NOT_FOUND_MEMBER"))
+            .andExpect(jsonPath("$.message").value("일치하는 회원을 찾을 수 없습니다."))
+            .andReturn();
+    }
+
+    @DisplayName("회원 정보 수정 실패 - 비밀번호 다름")
+    @Test
+    void Modify_Member_Info_Fail_Password() throws Exception {
+        //given
+        ModifyMember request = ModifyMember.builder()
+            .currentPassword("1234")
+            .updatePassword("")
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        given(memberService.modifyMemberInfo(any(), any())).willThrow(new RestApiException(PASSWORD_ENTERED_IS_INCORRECT));
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+            MockMvcRequestBuilders.put("/modify/member")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new Gson().toJson(request))
+        );
+
+        //then
+        MvcResult mvcResult = resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.errorCode").value("PASSWORD_ENTERED_IS_INCORRECT"))
+            .andExpect(jsonPath("$.message").value("입력하신 비밀번호가 올바르지 않습니다."))
+            .andReturn();
+    }
+}

--- a/src/test/java/com/su/look_at_meong/service/member/MemberServiceTest.java
+++ b/src/test/java/com/su/look_at_meong/service/member/MemberServiceTest.java
@@ -1,15 +1,22 @@
 package com.su.look_at_meong.service.member;
 
+import static com.su.look_at_meong.constatnt.Role.MEMBER;
+import static com.su.look_at_meong.exception.constant.MemberErrorCode.NOT_FOUND_MEMBER;
+import static com.su.look_at_meong.exception.constant.MemberErrorCode.PASSWORD_ENTERED_IS_INCORRECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.su.look_at_meong.exception.RestApiException;
 import com.su.look_at_meong.model.member.dto.MemberDto;
 import com.su.look_at_meong.model.member.dto.SignUpFormDto;
 import com.su.look_at_meong.model.member.entity.Member;
+import com.su.look_at_meong.model.member.entity.ModifyMember;
 import com.su.look_at_meong.repository.MemberRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,5 +69,82 @@ class MemberServiceTest {
         assertEquals("test2@test.com", captor.getValue().getEmail());
         assertEquals("test@test.com", memberDto.getEmail());
         assertEquals("홍길동", memberDto.getName());
+    }
+
+    @DisplayName("회원 정보 수정")
+    @Test
+    void MODIFY_MEMBER_INFO() {
+        //given
+        Member response = member();
+
+        ModifyMember request = ModifyMember.builder()
+            .currentPassword("1234")
+            .updatePassword("")
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        given(memberRepository.findByEmail(any())).willReturn(Optional.ofNullable(response));
+        given(memberRepository.save(any())).willReturn(response);
+
+        //when
+        var result = memberService.modifyMemberInfo("test@test.com", request);
+
+        //then
+        assertEquals("김나나", result.getName());
+        assertEquals("010-2222-1111", result.getPhone());
+    }
+
+    @DisplayName("회원 정보 수정 - 등록된 사용자 없음")
+    @Test
+    void MODIFY_MEMBER_INFO_FAIL() {
+        //given
+        ModifyMember request = ModifyMember.builder()
+            .currentPassword("1234")
+            .updatePassword("")
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        given(memberRepository.findByEmail(any())).willThrow(new RestApiException(NOT_FOUND_MEMBER));
+
+        //when
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> memberService.modifyMemberInfo("test1@test.com", request));
+
+        //then
+        assertEquals(NOT_FOUND_MEMBER, exception.getErrorCode());
+    }
+
+    @DisplayName("회원 정보 수정 - 비밀번호 불일치")
+    @Test
+    void MODIFY_MEMBER_INFO_PASSWORD_FAIL() {
+        //given
+        Member response = member();
+        ModifyMember request = ModifyMember.builder()
+            .currentPassword("1111")
+            .updatePassword("")
+            .name("김나나")
+            .phone("010-2222-1111")
+            .build();
+
+        given(memberRepository.findByEmail(any())).willReturn(Optional.ofNullable(response));
+
+        //when
+        RestApiException exception = assertThrows(RestApiException.class,
+            () -> memberService.modifyMemberInfo("test@test.com", request));
+
+        //then
+        assertEquals(PASSWORD_ENTERED_IS_INCORRECT, exception.getErrorCode());
+    }
+
+    private Member member() {
+        return Member.builder()
+            .email("test@test.com")
+            .password(passwordEncoder.encode("1234"))
+            .name("홍길동")
+            .phone("010-1111-1111")
+            .role(MEMBER)
+            .build();
     }
 }


### PR DESCRIPTION
Changes
---
- 회원 정보 수정(name, phone, password 만) api구현
- 회원 정보 수정시 현재 비밀번호와 일치해야 변경이 가능함
- 회원 정보 수정 서비스, 컨트롤러 테스트 구현

BackGround
---
- 회원 정보 수정 컨트롤러 테스트시 Principal 값이 null. 추후 리팩토링 필요.